### PR TITLE
feat: add opt-in remote mysql backup script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,9 +35,12 @@ jobs:
         run: |
           mkdir -p .debpkg/var/lib/Acronis/
           cp mysqlbackup.sh .debpkg/var/lib/Acronis/
+          cp mysqlbackup-remote.sh .debpkg/var/lib/Acronis/
+          cp mysqlbackup-all.sh .debpkg/var/lib/Acronis/
           cp mysqlfreeze.sh .debpkg/var/lib/Acronis/
           cp mysqlthaw.sh .debpkg/var/lib/Acronis/
           cp mysql.conf .debpkg/var/lib/Acronis/
+          cp mysql-remote.conf .debpkg/var/lib/Acronis/
           cp functions.sh .debpkg/var/lib/Acronis/
           chmod +x .debpkg/var/lib/Acronis/*.sh
 
@@ -45,6 +48,7 @@ jobs:
           mkdir -p .debpkg/DEBIAN
           touch .debpkg/DEBIAN/conffiles
           echo '/var/lib/Acronis/mysql.conf' >> .debpkg/DEBIAN/conffiles
+          echo '/var/lib/Acronis/mysql-remote.conf' >> .debpkg/DEBIAN/conffiles
       - uses: jiro4989/build-deb-action@v3
         with:
           package: acronis-mysql-scripts

--- a/README.md
+++ b/README.md
@@ -55,6 +55,45 @@ want or include both.
 11. Click **Done** and **Save changes** and apply it to the backup plan.
 12. Run the backup to test if things are working.
 
+## Remote backups
+
+By default these scripts back up MySQL on the same server. If you also want
+to back up a single remote MySQL server from this machine, an additional
+script is provided: `/var/lib/Acronis/mysqlbackup-remote.sh`. It is opt-in
+and is not used unless you configure and invoke it explicitly.
+
+1. Create a credentials file for the remote server, e.g.
+   `/root/.my-remote.cnf`:
+
+   ```ini
+   [client]
+   host = db2.example.com
+   user = backup
+   password = your-password-here
+   ```
+
+   Make sure it is only readable by root: `chmod 600 /root/.my-remote.cnf`.
+
+2. Edit `/var/lib/Acronis/mysql-remote.conf` to point at the credentials
+   file and pick a separate backup location, for example:
+
+   ```
+   extra_file = /root/.my-remote.cnf
+   backup_location = /backup/remote
+   local_retention = 2
+   ```
+
+3. Acronis only supports a single pre-backup command. Pick the one that
+   matches what you want to back up:
+
+   - Local only: `/var/lib/Acronis/mysqlbackup.sh`
+   - Remote only: `/var/lib/Acronis/mysqlbackup-remote.sh`
+   - Both: `/var/lib/Acronis/mysqlbackup-all.sh`
+
+   The combined script runs both backups independently, so a failure in
+   one does not block the other. The remote script only performs a
+   `mysqldump` — freeze and thaw remain local-only.
+
 ## Limitations
 
 These scripts have been tested on:

--- a/functions.sh
+++ b/functions.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 getValueFromConfig() {
-    if [ ! -f "${DIR}/mysql.conf" ]; then
-      >&2 echo 'Configuration file missing.'
+    CONFIG_FILE="${3:-mysql.conf}"
+
+    if [ ! -f "${DIR}/${CONFIG_FILE}" ]; then
+      >&2 echo "Configuration file ${CONFIG_FILE} missing."
       exit 1
     fi
 
@@ -10,7 +12,7 @@ getValueFromConfig() {
       >&2 echo "No default value set for ${1}"
     fi
 
-    VALUE=$(grep ${1} "${DIR}/mysql.conf" | cut -d '=' -f 2)
+    VALUE=$(grep ${1} "${DIR}/${CONFIG_FILE}" | cut -d '=' -f 2)
 
     # Return default value ($2) when no value exists
 

--- a/mysql-remote.conf
+++ b/mysql-remote.conf
@@ -1,0 +1,5 @@
+# Settings for remote MySQL backups in Acronis
+
+extra_file = /root/.my-remote.cnf
+backup_location = /backup/remote
+local_retention = 2

--- a/mysqlbackup-all.sh
+++ b/mysqlbackup-all.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+STATUS=0
+
+"${DIR}/mysqlbackup.sh" || STATUS=$?
+"${DIR}/mysqlbackup-remote.sh" || STATUS=$?
+
+exit $STATUS

--- a/mysqlbackup-remote.sh
+++ b/mysqlbackup-remote.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+unset LD_LIBRARY_PATH
+unset LD_PRELOAD
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+source "${DIR}/functions.sh"
+
+EXTRA_FILE=$(getValueFromConfig extra_file "" mysql-remote.conf)
+BACKUP_LOCATION=$(getValueFromConfig backup_location /backup/remote mysql-remote.conf)
+LOCAL_RETENTION=$(getValueFromConfig local_retention 2 mysql-remote.conf)
+DATE=$(date +"%Y%m%d")
+
+if [ -z "${EXTRA_FILE}" ]; then
+  >&2 echo "extra_file is not set in mysql-remote.conf"
+  exit 1
+fi
+
+if [ ! -f "${EXTRA_FILE}" ]; then
+  >&2 echo "credentials file ${EXTRA_FILE} does not exist"
+  exit 1
+fi
+
+if [ "${BACKUP_LOCATION}" = "/" ]; then
+  >&2 echo "backup_location cannot be set to /"
+  exit 1
+fi
+
+DATABASES=$(mysql --defaults-extra-file="$EXTRA_FILE" -N -e "SHOW DATABASES" | grep -Ev '^(information_schema|performance_schema|mysql)$')
+
+mkdir -p "${BACKUP_LOCATION}/${DATE}"
+
+for DB in $DATABASES; do
+  echo -n $DB
+  mysqldump --defaults-extra-file="${EXTRA_FILE}" --force --skip-lock-tables --events --routines --databases "${DB}" | gzip > "${BACKUP_LOCATION}/${DATE}/${DB}.sql.gz"
+  echo " OK"
+done
+
+find "${BACKUP_LOCATION}/" -type f -mtime +"${LOCAL_RETENTION}" -delete -print || true
+find "${BACKUP_LOCATION}/" -type d -empty -delete -print || true

--- a/rpmbuild/SPECS/acronis-mysql-scripts.spec
+++ b/rpmbuild/SPECS/acronis-mysql-scripts.spec
@@ -10,16 +10,23 @@ Backups scripts to be used by Acronis to make backups of MySQL.
 %install
 mkdir -p %{buildroot}/var/lib/Acronis/
 cp /srv/mysqlbackup.sh %{buildroot}/var/lib/Acronis/
+cp /srv/mysqlbackup-remote.sh %{buildroot}/var/lib/Acronis/
+cp /srv/mysqlbackup-all.sh %{buildroot}/var/lib/Acronis/
 cp /srv/mysqlfreeze.sh %{buildroot}/var/lib/Acronis/
 cp /srv/mysqlthaw.sh %{buildroot}/var/lib/Acronis/
 cp /srv/mysql.conf %{buildroot}/var/lib/Acronis/
+cp /srv/mysql-remote.conf %{buildroot}/var/lib/Acronis/
 cp /srv/functions.sh %{buildroot}/var/lib/Acronis/
 
 %files
 %attr(0755, root, root) /var/lib/Acronis/mysqlbackup.sh
+%attr(0755, root, root) /var/lib/Acronis/mysqlbackup-remote.sh
+%attr(0755, root, root) /var/lib/Acronis/mysqlbackup-all.sh
 %attr(0755, root, root) /var/lib/Acronis/mysqlfreeze.sh
 %attr(0755, root, root) /var/lib/Acronis/mysqlthaw.sh
 %attr(-, root, root) /var/lib/Acronis/mysql.conf
+%attr(-, root, root) /var/lib/Acronis/mysql-remote.conf
 %attr(-, root, root) /var/lib/Acronis/functions.sh
 
 %config(noreplace) /var/lib/Acronis/mysql.conf
+%config(noreplace) /var/lib/Acronis/mysql-remote.conf


### PR DESCRIPTION
## Description

Adds an opt-in flow for backing up a single remote MySQL server alongside the existing local backups. The default install behaves exactly as before — nothing remote runs unless you explicitly configure and invoke it.

Three scripts are now available under `/var/lib/Acronis/`:

- `mysqlbackup.sh` — local backups (unchanged)
- `mysqlbackup-remote.sh` — runs `mysqldump` against a remote host using its own credentials file and a separate backup location
- `mysqlbackup-all.sh` — runs both of the above independently, so a failing remote backup does not block the local one (and vice versa)

Because Acronis only allows one pre-backup command, the README now explains which script to point Acronis at depending on whether you want local only, remote only, or both.

The remote connection is configured entirely through a standard MySQL credentials file (e.g. `/root/.my-remote.cnf` with `[client]` containing `host`, `user`, `password`), referenced from a new `mysql-remote.conf`. No `--host` flag is needed in the scripts. Freeze and thaw remain local-only on purpose — coordinating them remotely is a separate, much larger concern.

`getValueFromConfig` in `functions.sh` now takes an optional third argument for the config filename, defaulting to `mysql.conf`, so existing callers are unaffected.

Both RPM and DEB packaging include the new files, and the new config is marked as a non-replacing config file so package upgrades will not overwrite user edits.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.