### PR TITLE
feat: add skip_databases config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ and is not used unless you configure and invoke it explicitly.
    local_retention = 2
    ```
 
+   On managed MySQL services the backup user often does not have
+   `SHOW VIEW` on the `sys` schema. Skip it with a comma-separated
+   `skip_databases` value:
+
+   ```
+   skip_databases = sys
+   ```
+
+   The same `skip_databases` key works in `mysql.conf` for local
+   backups.
+
 3. Acronis only supports a single pre-backup command. Pick the one that
    matches what you want to back up:
 

--- a/functions.sh
+++ b/functions.sh
@@ -8,7 +8,7 @@ getValueFromConfig() {
       exit 1
     fi
 
-    if [ -z $2 ]; then
+    if [ -z $2 ] && [ "$1" != "skip_databases" ]; then
       >&2 echo "No default value set for ${1}"
     fi
 

--- a/mysql-remote.conf
+++ b/mysql-remote.conf
@@ -3,3 +3,4 @@
 extra_file = /root/.my-remote.cnf
 backup_location = /backup/remote
 local_retention = 2
+skip_databases =

--- a/mysql.conf
+++ b/mysql.conf
@@ -5,3 +5,4 @@ freeze_mysql_timeout = 300
 freeze_snapshot_timeout = 5
 local_retention = 2
 logging_location = /var/lib/Acronis/logs
+skip_databases =

--- a/mysqlbackup-remote.sh
+++ b/mysqlbackup-remote.sh
@@ -11,6 +11,7 @@ source "${DIR}/functions.sh"
 EXTRA_FILE=$(getValueFromConfig extra_file "" mysql-remote.conf)
 BACKUP_LOCATION=$(getValueFromConfig backup_location /backup/remote mysql-remote.conf)
 LOCAL_RETENTION=$(getValueFromConfig local_retention 2 mysql-remote.conf)
+SKIP_DATABASES=$(getValueFromConfig skip_databases "" mysql-remote.conf)
 DATE=$(date +"%Y%m%d")
 
 if [ -z "${EXTRA_FILE}" ]; then
@@ -28,7 +29,12 @@ if [ "${BACKUP_LOCATION}" = "/" ]; then
   exit 1
 fi
 
-DATABASES=$(mysql --defaults-extra-file="$EXTRA_FILE" -N -e "SHOW DATABASES" | grep -Ev '^(information_schema|performance_schema|mysql)$')
+FILTER='^(information_schema|performance_schema|mysql)$'
+if [ -n "$SKIP_DATABASES" ]; then
+  FILTER="^(information_schema|performance_schema|mysql|$(echo "$SKIP_DATABASES" | tr ',' '|'))$"
+fi
+
+DATABASES=$(mysql --defaults-extra-file="$EXTRA_FILE" -N -e "SHOW DATABASES" | grep -Ev "$FILTER")
 
 mkdir -p "${BACKUP_LOCATION}/${DATE}"
 

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -13,6 +13,7 @@ source "${DIR}/functions.sh"
 
 BACKUP_LOCATION=$(getValueFromConfig backup_location /backup)
 LOCAL_RETENTION=$(getValueFromConfig local_retention 2)
+SKIP_DATABASES=$(getValueFromConfig skip_databases "")
 DATE=$(date +"%Y%m%d")
 EXTRA_FILE=/root/.my.cnf
 
@@ -30,7 +31,12 @@ if [ "${BACKUP_LOCATION}" = "/" ]; then
   exit 1
 fi
 
-DATABASES=$(mysql --defaults-extra-file="$EXTRA_FILE" -N -e "SHOW DATABASES" | grep -Ev '^(information_schema|performance_schema|mysql)$')
+FILTER='^(information_schema|performance_schema|mysql)$'
+if [ -n "$SKIP_DATABASES" ]; then
+  FILTER="^(information_schema|performance_schema|mysql|$(echo "$SKIP_DATABASES" | tr ',' '|'))$"
+fi
+
+DATABASES=$(mysql --defaults-extra-file="$EXTRA_FILE" -N -e "SHOW DATABASES" | grep -Ev "$FILTER")
 
 mkdir -p "${BACKUP_LOCATION}/${DATE}"
 


### PR DESCRIPTION
## Description

Adds an opt-in `skip_databases` config key for excluding additional databases from the backup loop, beyond the three MySQL internal schemas (`information_schema`, `performance_schema`, `mysql`) that are already hardcoded.

The motivating case: on some managed MySQL services the backup user does not have `SHOW VIEW` on the `sys` schema, so `mysqldump` emits a permission error for every view in `sys` on every run. With `skip_databases = sys` the entire `sys` schema is skipped at the `SHOW DATABASES` step and the noise disappears.

The default value is empty in both `mysql.conf` and `mysql-remote.conf`, so existing installations behave exactly as before — `sys` and any other non-internal schemas keep being dumped unless the user explicitly opts in.

The value is a comma-separated list of database names, e.g.:

```
skip_databases = sys,scratch,old_archive
```

Both the local (`mysqlbackup.sh`) and remote (`mysqlbackup-remote.sh`) scripts read the key from their respective config files. A small carve-out was added to `getValueFromConfig` so it does not warn about a missing default for `skip_databases`, since an empty default is intentional here.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.